### PR TITLE
Change cost of a jump to 0

### DIFF
--- a/api/gameserver/game_instance.go
+++ b/api/gameserver/game_instance.go
@@ -200,6 +200,10 @@ func (g *gameInstance) startIfReady() {
 }
 
 func (g *gameInstance) MakeMove(authorization user.Authorization, move scouts.Move) error {
+	if g.state.BeganAt == nil {
+		return fmt.Errorf("%w: less than two players in game", ErrInvalidGameState)
+	}
+
 	now := g.clock.Now()
 
 	g.mu.Lock()

--- a/api/gameserver/game_manager.go
+++ b/api/gameserver/game_manager.go
@@ -20,6 +20,9 @@ var ErrGameFull = hrt.NewHTTPError(400, "game already has two players")
 // ErrInvalidMove is an error that is returned when a move is invalid.
 var ErrInvalidMove = hrt.NewHTTPError(400, "invalid move")
 
+// ErrInvalidMove is an error that is returned when a move is invalid.
+var ErrInvalidGameState = hrt.NewHTTPError(400, "invalid game state")
+
 // CreateGameOptions is a struct that contains options for creating a game.
 // All fields are optional.
 type CreateGameOptions struct {

--- a/scouts/move_jump.go
+++ b/scouts/move_jump.go
@@ -61,16 +61,9 @@ func (m *JumpMove) UnmarshalText(text []byte) error {
 	return nil
 }
 
-func (m *JumpMove) cost(game *Game) int {
-	if len(game.currentTurn.Moves) > 0 {
-		lastMove := game.currentTurn.Moves[len(game.currentTurn.Moves)-1]
-		if jump, ok := lastMove.(*JumpMove); ok && jump.Destination == m.ScoutPosition {
-			// This jump is free because we're jumping the same scout as the last
-			// jump.
-			return 0
-		}
-	}
-	return 1
+// TODO: this needs to be updated. Jumping should only cost a play if the piece was flipped
+func (m *JumpMove) cost(_ *Game) int {
+	return 0
 }
 
 // Apply applies the move to the board.
@@ -148,7 +141,8 @@ func (m *JumpMove) apply(game *Game) {
 		}
 	}
 
-	game.addMove(m, m.cost(game))
+	// game.addMove(m, m.cost(game))
+	game.addMove(m, 0)
 }
 
 func abs[T constraints.Integer](x T) T {


### PR DESCRIPTION
The cost of a jump should be 0 except for the edge case where a jump results in a scout acquiring intel. Temporarily, I've set the cost to 0, and I will cover the edge case later.